### PR TITLE
Expose getSemanticHTML method to event handlers

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,7 +67,8 @@ namespace ReactQuill {
   export interface UnprivilegedEditor {
     getLength: Quill['getLength'];
     getText: Quill['getText'];
-    getHTML: Quill['getSemanticHTML'];
+    getHTML: string;
+    getSemanticHTML: Quill['getSemanticHTML'];
     getBounds: Quill['getBounds'];
     getSelection: Quill['getSelection'];
     getContents: Quill['getContents'];
@@ -419,12 +420,13 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
   makeUnprivilegedEditor(editor: Quill) {
     const e = editor;
     return {
-      getHTML:      () => e.root.innerHTML,
-      getLength:    e.getLength.bind(e),
-      getText:      e.getText.bind(e),
-      getContents:  e.getContents.bind(e),
-      getSelection: e.getSelection.bind(e),
-      getBounds:    e.getBounds.bind(e),
+      getHTML:         () => e.root.innerHTML,
+      getSemanticHTML: e.getSemanticHTML.bind(e),
+      getLength:       e.getLength.bind(e),
+      getText:         e.getText.bind(e),
+      getContents:     e.getContents.bind(e),
+      getSelection:    e.getSelection.bind(e),
+      getBounds:       e.getBounds.bind(e),
     };
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -67,7 +67,7 @@ namespace ReactQuill {
   export interface UnprivilegedEditor {
     getLength: Quill['getLength'];
     getText: Quill['getText'];
-    getHTML: string;
+    getHTML: () => string;
     getSemanticHTML: Quill['getSemanticHTML'];
     getBounds: Quill['getBounds'];
     getSelection: Quill['getSelection'];


### PR DESCRIPTION
This PR is about exposing the [getSemanticHTML](https://quilljs.com/docs/api#getsemantichtml) method to event handlers.

```jsx
<ReactQuill
  onBlur={(range, source, editor) => {
    console.log(editor.getSemanticHTML());
  }}
  // other props
/>
```

The getSemanticHTML method returns the semantic HTML representation. This result is different from the `editor.getHTML()` method which returns just the editor contents.

Example:
```html
<!-- getHTML() -->
<ol>
<li data-list="bullet"><span class="ql-ui" contenteditable="false"></span>one</li>
<li data-list="bullet"><span class="ql-ui" contenteditable="false"></span>two</li>
</ol>
```

```html
<!-- getSemanticHTML() -->
<ul>
<li>one</li>
<li>two</li>
</ul>
```