### PR TITLE
Delete findDomNode usage and scrolling container

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,6 @@ namespace ReactQuill {
   export type Range = RangeStatic | null;
 
   export interface QuillOptions extends QuillOptionsStatic {
-    strict?: boolean | undefined,
     tabIndex?: number,
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,7 @@ React-Quill
 https://github.com/zenoamaro/react-quill
 */
 
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, { createRef } from 'react';
 import isEqual from 'lodash/isEqual';
 
 import Quill, { type EmitterSource, type Range as RangeStatic, QuillOptions as QuillOptionsStatic } from 'quill';
@@ -17,7 +16,6 @@ namespace ReactQuill {
   export type Range = RangeStatic | null;
 
   export interface QuillOptions extends QuillOptionsStatic {
-    scrollingContainer?: HTMLElement | string | undefined,
     strict?: boolean | undefined,
     tabIndex?: number,
   }
@@ -57,7 +55,6 @@ namespace ReactQuill {
     placeholder?: string,
     preserveWhitespace?: boolean,
     readOnly?: boolean,
-    scrollingContainer?: string | HTMLElement,
     style?: React.CSSProperties,
     tabIndex?: number,
     theme?: string,
@@ -86,6 +83,7 @@ interface ReactQuillState {
 }
 
 class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
+  editingAreaRef = createRef<any>();
 
   static displayName = 'React Quill'
 
@@ -139,11 +137,6 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
   The Quill Editor instance.
   */
   editor?: Quill
-
-  /*
-  Reference to the element holding the Quill editing area.
-  */
-  editingArea?: React.ReactInstance | null
 
   /*
   Tracks the internal value of the Quill editor
@@ -309,7 +302,6 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
       modules: this.props.modules,
       placeholder: this.props.placeholder,
       readOnly: this.props.readOnly,
-      scrollingContainer: this.props.scrollingContainer,
       tabIndex: this.props.tabIndex,
       theme: this.props.theme,
     };
@@ -429,10 +421,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
   }
 
   getEditingArea(): HTMLElement {
-    if (!this.editingArea) {
-      throw new Error('Instantiating on missing editing area');
-    }
-    const element = ReactDOM.findDOMNode(this.editingArea);
+    const element = this.editingAreaRef.current;
     if (!element) {
       throw new Error('Cannot find element for editing area');
     }
@@ -451,9 +440,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
 
     const properties = {
       key: generation,
-      ref: (instance: React.ReactInstance | null) => {
-        this.editingArea = instance
-      },
+      ref: this.editingAreaRef,
     };
 
     if (React.Children.count(children)) {


### PR DESCRIPTION
`findDomNode` deleted from React 19
`scrollingContainer` and `strict` [deleted](https://quilljs.com/docs/upgrading-to-2-0#options) from Quill 2