### PR TITLE
fix: editor crash on dirty props change

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -289,6 +289,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
   destroyEditor(): void {
     if (!this.editor) return;
     this.unhookEditor(this.editor);
+    delete this.editor;
   }
 
   /*


### PR DESCRIPTION
If one of the dirty props changes (so as not to be `_.isEqual`), the editor will go blank and no longer allow changes.

This is because the editing area `div` is recreated on generation change, but Quill is only instantiated once on setup and therefore the reference Quill has to the editing area is never updated - it continues to reference and make changes to the original `div`  but that div is no longer displayed anywhere on the page, and the new div is never changed from being a blank element.

I have put a minimal reproduction [here](https://github.com/RobertStanyon/react-quill/tree/crash-repoduction), and the following is a screencast of it:
[Screencast from 2025-01-21 13-27-12.webm](https://github.com/user-attachments/assets/3790c940-1dbd-4af6-9611-6f100a13cf33)
To reproduce, just build the module and run the demo - go to the page and click into the editor to focus it, this causes the editor to crash.

The modules prop I use in the example is contrived and not a valid prop, but the `_.isEqual` check on the dirty props compares functions only by `===`, so any non-memoized function included in a dirty prop (e.g. a toolbar handler) will cause the `isEqual` to fail.