### PR TITLE
preventing custom toolbar removal toolbar param is string

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -295,6 +295,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
     // We check for and remove the toolbar if it exists, but only if we're not using
     // a custom external toolbar (which we don't want to remove).
     const toolbar = this.props.modules?.toolbar;
+    // This checks if toolbar is set to anything BUT {toolbar: "<string>"} OR {toolbar: {container: "<string>"}}
     if (
       !toolbar ||
       typeof toolbar !== 'object' ||

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -295,8 +295,13 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
     // We check for and remove the toolbar if it exists, but only if we're not using
     // a custom external toolbar (which we don't want to remove).
     const toolbar = this.props.modules?.toolbar;
-    if (!toolbar || typeof toolbar !== 'object' || !('container' in toolbar)) {
-      const leftOverToolbar = document.querySelector(".ql-toolbar");
+    if (
+      !toolbar ||
+      typeof toolbar !== 'object' ||
+      !('container' in toolbar) ||
+      typeof toolbar !== 'string'
+    ) {
+      const leftOverToolbar = document.querySelector('.ql-toolbar');
       if (leftOverToolbar) {
         leftOverToolbar.remove();
       }


### PR DESCRIPTION
In the fix was introduced in https://github.com/VaguelySerious/react-quill/commit/86679706e1166444ea4f326ff377a902b7aba24c to avoid the toolbar removal in case the toolbar is custom, one case was missed, which was if the toolbar container can be directly passed as string as the value of toolbar param, for example 👇🏼 
```
{
   toolbar: "#custom-quill-toolbar"
} 
```
is same as 
```
{
   toolbar: {
      container: "#custom-quill-toolbar"
   }
} 
```
This was a small shorthand introduced by quill in v2, it's mentioned in it's documentation 👉🏼 https://quilljs.com/docs/modules/toolbar

This PR adds the support for the shorthand in the earlier fix